### PR TITLE
Typo fix

### DIFF
--- a/docs/settings_kb/interface/Темы_интерфейса.rst
+++ b/docs/settings_kb/interface/Темы_интерфейса.rst
@@ -117,4 +117,4 @@ API
 
 Чтобы избежать проблем с кэшем (темы могут меняться “на лету”) нужно добавлять в запросы ключ кэширования, который загружается по следующему API::
 
- await Citeck.Records.get('uiserv/meta@').load('attributes.theme-cache-key')
+ await Citeck.Records.get('uiserv/meta@').load('attributes.theme-cache-key');


### PR DESCRIPTION
Lost semicolon added in Themes documentation